### PR TITLE
chore: minor fix on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pipe(conn, muxer, conn) // conn is duplex connection to another peer
         stream,
         source => (async function * () {
           for await (const data of source) yield data
-        })()
+        })(),
         stream
       )
     }


### PR DESCRIPTION
Missing comma on example with `pipe` added